### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,11 @@ on:
   schedule:
   - cron: '0 0 * * *'
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/thomasthaddeus/DSClub/security/code-scanning/4](https://github.com/thomasthaddeus/DSClub/security/code-scanning/4)

Add an explicit `permissions` block to `.github/workflows/stale.yml` so the workflow only gets the scopes required by `actions/stale@v4`.

Best fix here: add workflow-level permissions (applies to all jobs in this file) directly under `on:` (or before `jobs:`). For stale automation, the minimal practical permissions are:
- `contents: write` (per CodeQL suggested baseline for this action pattern),
- `issues: write`,
- `pull-requests: write`.

This preserves existing behavior (marking/closing stale issues and PRs) while enforcing least privilege explicitly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
