### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codespaces.yml
+++ b/.github/workflows/codespaces.yml
@@ -1,6 +1,9 @@
 # Path: .github/workflows/codespaces.yml
 name: "Codespaces"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/thomasthaddeus/DSClub/security/code-scanning/2](https://github.com/thomasthaddeus/DSClub/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained rather than inheriting defaults.

Best single fix here (without changing behavior beyond token scoping) is to add a workflow-level `permissions` section directly under `name`/before `on`, starting with the CodeQL-recommended minimum:
- `contents: read`

File/region to change:
- `.github/workflows/codespaces.yml`
- Insert the `permissions` block near the top-level keys (after `name` is the cleanest placement).

No imports, methods, or extra definitions are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
